### PR TITLE
chore: update the threashold from 75 to 66

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -182,7 +182,7 @@ profiles:
   #
   governance:
     duration: 4w
-    pass_threshold: 75
+    pass_threshold: 66
     close_on_passing: true
     announcements:
       discussions:


### PR DESCRIPTION
The votes requires 66% (2/3) following our governance,
we requiring more than that (75%).