### PR TITLE
chore: add Floor Drees as component owner

### DIFF
--- a/COMPONENT-OWNERS.md
+++ b/COMPONENT-OWNERS.md
@@ -41,6 +41,7 @@
 - Gabriele Bartolini (@gbartolini, Maintainer)
 - Jonathan Battiato (@jbattiato)
 - Jaime Silvela (@jsilvela)
+- Floor Drees (@FloorD)
 
 ## cloudnative-pg
 


### PR DESCRIPTION
Added Floor Drees to the cloudnative-pg.github.io list of component owner