### PR TITLE
governance: transition Philippe Scorsolini to Emeritus Maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,4 +9,10 @@ order):
 - Jonathan Gonzalez (EDB)
 - Marco Nenciarini (EDB)
 - Armando Ruocco (EDB)
+
+## Emeritus Maintainers
+
+The following individuals have previously served as maintainers and are
+recognised for their valuable contributions to the project:
+
 - Philippe Scorsolini (Upbound)


### PR DESCRIPTION
Following a vote by the maintainer group (6/7 in favour) conducted via private email on 11 May 2026, Philippe Scorsolini transitions to Emeritus Maintainer status.

Closes #58